### PR TITLE
File loader improvements

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -1,13 +1,12 @@
 import { Text, Window, hot, View } from "@nodegui/react-nodegui";
 import React from "react";
 import { QIcon } from "@nodegui/nodegui";
-import path from "path";
 import { StepOne } from "./components/stepone";
 import { StepTwo } from "./components/steptwo";
 import nodeguiIcon from "../assets/nodegui.jpg";
 
 const minSize = { width: 500, height: 520 };
-const winIcon = new QIcon(path.resolve(__dirname, nodeguiIcon));
+const winIcon = new QIcon(nodeguiIcon);
 class App extends React.Component {
   render() {
     return (

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -27,7 +27,7 @@ module.exports = (env, argv) => {
           }
         },
         {
-          test: /\.(png|jpe?g|gif|svg|bmp)$/i,
+          test: /\.(png|jpe?g|gif|svg|bmp|otf)$/i,
           use: [{ loader: "file-loader" }]
         },
         {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -28,7 +28,12 @@ module.exports = (env, argv) => {
         },
         {
           test: /\.(png|jpe?g|gif|svg|bmp|otf)$/i,
-          use: [{ loader: "file-loader" }]
+          use: [{
+            loader: "file-loader",
+            options: {
+              publicPath: "dist"
+            }
+          }]
         },
         {
           test: /\.node/i,


### PR DESCRIPTION
'publicPath' option is required to seamlessly import assets like images and fonts without any `resolve` calls and `__dirname`