### PR TITLE
Fix `module.hot` TypeScript error

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,7 +6,8 @@
     "strict": true,
     "alwaysStrict": true,
     "moduleResolution": "node",
-    "esModuleInterop": true
+    "esModuleInterop": true,
+    "types": ["webpack-env"]
   },
   "include": ["**/*"]
 }


### PR DESCRIPTION
Fixes TypeScript error: Property 'hot' does not exist on type 'NodeModule'.